### PR TITLE
improvement: enable cache on eslint and stylelint, and moved lint-sta…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ typings/
 # Optional eslint cache
 .eslintcache
 
+# Optional stylelint cache
+.stylelintcache
+
 # Optional REPL history
 .node_repl_history
 

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,12 +1,31 @@
-const fileLimit = 10;
+const chunkFiles = require("lint-staged/lib/chunkFiles");
+
+// The linters fail for very large lists of files
+const MAX_ARGUMENT_LENGTH = 8000;
+
+const sharedTasks = ["prettier --write"];
 
 module.exports = {
     "./src/**/*.*(js|jsx|ts|tsx)": [
-        "prettier --write",
-        filenames => (filenames.length > fileLimit ? "eslint ./src/**/*.*(js|jsx|ts|tsx)" : `eslint --cache ${filenames.join(" ")}`),
+        ...sharedTasks,
+        allFiles => {
+            const chunkedFiles = chunkFiles({
+                files: allFiles,
+                maxArgLength: MAX_ARGUMENT_LENGTH,
+                gitDir: "./",
+            });
+            return chunkedFiles.map(chunk => `eslint --cache -- ${chunk.join(" ")}`);
+        },
     ],
     "./src/**/*.*(css|scss)": [
-        "prettier --write",
-        filenames => (filenames.length > fileLimit ? "stylelint ./src/**/*.*(css|scss)" : `stylelint --cache ${filenames.join(" ")}`),
+        ...sharedTasks,
+        allFiles => {
+            const chunkedFiles = chunkFiles({
+                files: allFiles,
+                maxArgLength: MAX_ARGUMENT_LENGTH,
+                gitDir: "./",
+            });
+            return chunkedFiles.map(chunk => `stylelint --cache -- ${chunk.join(" ")}`);
+        },
     ],
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,12 @@
+const fileLimit = 10;
+
+module.exports = {
+    "./src/**/*.*(js|jsx|ts|tsx)": [
+        "prettier --write",
+        filenames => (filenames.length > fileLimit ? "eslint ./src/**/*.*(js|jsx|ts|tsx)" : `eslint --cache ${filenames.join(" ")}`),
+    ],
+    "./src/**/*.*(css|scss)": [
+        "prettier --write",
+        filenames => (filenames.length > fileLimit ? "stylelint ./src/**/*.*(css|scss)" : `stylelint --cache ${filenames.join(" ")}`),
+    ],
+};

--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "frontline-starter",
   "private": true,
   "scripts": {
-    "clean": "rimraf dist",
-    "build": "npm run clean && cross-env NODE_ENV=production webpack --mode production",
     "start": "cross-env NODE_ENV=development webpack-dev-server --mode development",
+    "build": "npm run clean && cross-env NODE_ENV=production webpack --mode production",
+    "clean": "rimraf dist",
     "analyze:legacy": "webpack-bundle-analyzer dist/stats.legacy.json -p 8888",
     "analyze:modern": "webpack-bundle-analyzer dist/stats.modern.json -p 8889",
-    "prettier": "prettier --write \"src/**/*.*(js|jsx|json|css|scss)\"",
-    "eslint": "eslint --fix \"src/**/*.*(js|jsx)\"",
-    "stylelint": "stylelint --fix \"src/**/*.*(css|scss)\""
+    "prettier": "prettier --write \"src/**/*.*(js|jsx|ts|tsx|css|scss)\"",
+    "eslint": "eslint --fix --cache \"src/**/*.*(js|jsx|ts|tsx)\"",
+    "stylelint": "stylelint --fix --cache \"src/**/*.*(css|scss)\""
   },
   "devDependencies": {
     "@akqa-frontline/asset-config-webpack-plugin": "0.7.1",
@@ -59,15 +59,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "lint-staged": {
-    "src/**/*.*(js|jsx)": [
-      "prettier --write",
-      "eslint src/**/*.*(js|jsx) --fix"
-    ],
-    "src/**/*.*(css|scss)": [
-      "prettier --write",
-      "stylelint src/**/*.*(css|scss) --fix"
-    ]
   }
 }

--- a/src/styles/base/normalize.scss
+++ b/src/styles/base/normalize.scss
@@ -1,4 +1,4 @@
-﻿// Various variables and similar are available in the Normalize.scss library.
+// Various variables and similar are available in the Normalize.scss library.
 // Inspect the following file to learn more!
 @import "~normalize-scss/sass/normalize";
 

--- a/src/styles/base/variables.scss
+++ b/src/styles/base/variables.scss
@@ -1,4 +1,4 @@
-﻿//
+//
 // Variables
 //
 // Set all your variables in this file. Please adhere

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,4 +1,4 @@
-﻿@import "base/normalize";
+@import "base/normalize";
 @import "base/variables";
 @import "base/base";
 @import "base/typography";


### PR DESCRIPTION
- Enable cache on eslint and stylelint
- Move lint-staged to separate script with a file limit
- Change order of npm scripts in package.json for editors, that support listing npm scripts (see screenshot)

A file limit on lint-staget is helpful when committing a ton of files (like when merging two branches), shich can cause lint-staged to break, because the automatically generated CLI command is longer than 256 character or whatever.

![image](https://user-images.githubusercontent.com/6906782/75877308-b27cbf00-5e17-11ea-9eee-e70fac12e8cf.png)
